### PR TITLE
Fix broken row

### DIFF
--- a/2015/counties/20151103__ms__general__leflore__precinct.csv
+++ b/2015/counties/20151103__ms__general__leflore__precinct.csv
@@ -420,11 +420,10 @@ Leflore,West Gwd,State Treasurer,,Republican,Lynn Fitch,212
 Leflore,West Gwd,State Treasurer,,Reform,Viola McFarland,240
 Leflore,West Gwd,Commissioner of Agriculture & Commerce,,Democrat,Addie Lee Green,464
 Leflore,West Gwd,Commissioner of Agriculture & Commerce,,Republican,Cindy Hyde-Smith,110
-Leflore,West Gwd,Commissioner of Agriculture & Commerce,,Reform,Cathy L
+Leflore,West Gwd,Commissioner of Agriculture & Commerce,,Reform,Cathy L Toole,23
 Leflore,West Gwd,State Senate,14,Democrat,Georgio Proctor,40
 Leflore,West Gwd,State Senate,14,Republican,Lydia Graves Chassaniol,11
 Leflore,West Gwd,State Senate,14,Independent,Donny Ryals,2
-Toole,23
 Leflore,West Gwd,Commissioner of Insurance,,Republican,Mike Chaney,353
 Leflore,West Gwd,State Senate,24,Democrat,David Jordan,517
 Leflore,West Gwd,State House,32,Democrat,Willie J Perkins Sr,541


### PR DESCRIPTION
This fixes a row that was broken across two non-contiguous lines.  It appears that this was accidentally broken in revision be63312c9.

It can be verified from the [original source](https://sos.ms.gov/elections/electionresults/2015General/county%20Recaps/Leflore%20County.pdf) that Cathy L Toole received 23 votes in the West Gwd district.